### PR TITLE
Deploy the lite psm instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Intended to be used with the first version of the USDC PSM at `0x89B78CfA322F6C5
 The code is written in a general way, but it is expected for this to be used with the USDC PSM and sDAI. Please note that all values are measured in either USDC or DAI and not sDAI shares. This keeps the UI simple in that you can specify `100e18` of sDAI to mean "100 DAI worth of sDAI" instead of doing the share conversion.
 
 Deployed at (Original PSM): [0x52d298ff9e77e71c2eb1992260520e7b15257d99](https://etherscan.io/address/0x52d298ff9e77e71c2eb1992260520e7b15257d99)  
-Deployed at (PSM Lite): TBD  
+Deployed at (PSM Lite): [0x5803199F1085d52D1Bb527f24Dc1A2744e80A979](https://etherscan.io/address/0x5803199F1085d52D1Bb527f24Dc1A2744e80A979)  
 Deployed at (NST PSM Wrapper): TBD  
 
 ### swapAndDeposit

--- a/foundry.toml
+++ b/foundry.toml
@@ -2,7 +2,7 @@
 src = "src"
 out = "out"
 libs = ["lib"]
-solc_version = '0.8.25'
+solc_version = '0.8.26'
 optimizer = true
 optimizer_runs = 100000
 

--- a/test/fork/PSMVariant1Actions.t.sol
+++ b/test/fork/PSMVariant1Actions.t.sol
@@ -6,8 +6,6 @@ import "forge-std/Test.sol";
 import { IERC20 }   from "forge-std/interfaces/IERC20.sol";
 import { IERC4626 } from "forge-std/interfaces/IERC4626.sol";
 
-import { VmSafe } from "forge-std/Vm.sol";
-
 import { PSMVariant1Actions } from "src/PSMVariant1Actions.sol";
 
 interface PotLike {

--- a/test/fork/PSMVariant2Actions.t.sol
+++ b/test/fork/PSMVariant2Actions.t.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+
+import { IERC20 }   from "forge-std/interfaces/IERC20.sol";
+import { IERC4626 } from "forge-std/interfaces/IERC4626.sol";
+
+import { PSMVariant1Actions } from "src/PSMVariant1Actions.sol";
+
+// Testing the actual deploy of PSMVariant1Actions pointed at the PSM Lite
+contract PSMVariant2ActionsIntegrationTest is Test {
+
+    address constant PSM_LITE = 0xf6e72Db5454dd049d0788e411b06CfAF16853042;
+
+    address constant DAI  = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
+    address constant SDAI = 0x83F20F44975D03b1b09e64809B757c47f942BEeA;
+    address constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+
+    IERC20   constant dai  = IERC20(DAI);
+    IERC20   constant usdc = IERC20(USDC);
+    IERC4626 constant sdai = IERC4626(SDAI);
+
+    PSMVariant1Actions actions = PSMVariant1Actions(0x5803199F1085d52D1Bb527f24Dc1A2744e80A979);
+
+    function setUp() public virtual {
+        vm.createSelectFork(getChain('mainnet').rpcUrl, 20426716);  // Jul 31, 2024
+    }
+
+    function test_deploy() public view {
+        assertEq(address(actions.psm()),          PSM_LITE);
+        assertEq(address(actions.dai()),          DAI);
+        assertEq(address(actions.gem()),          USDC);
+        assertEq(address(actions.savingsToken()), SDAI);
+    }
+
+    function test_swapAndDeposit() public {
+        deal(USDC, address(this), 100e6);
+        usdc.approve(address(actions), 100e6);
+
+        assertEq(usdc.balanceOf(address(this)),                       100e6);
+        assertEq(sdai.convertToAssets(sdai.balanceOf(address(this))), 0);
+
+        actions.swapAndDeposit(address(this), 100e6, 100e18);
+
+        assertEq(usdc.balanceOf(address(this)),                       0);
+        assertEq(sdai.convertToAssets(sdai.balanceOf(address(this))), 99.999999999999999999e18);  // Rounding
+    }
+
+    function test_withdrawAndSwap() public {
+        uint256 shares = sdai.convertToShares(100e18);
+        deal(SDAI, address(this), shares);
+        sdai.approve(address(actions), shares);
+
+        assertEq(usdc.balanceOf(address(this)),                       0);
+        assertEq(sdai.convertToAssets(sdai.balanceOf(address(this))), 99.999999999999999999e18);  // Rounding
+
+        // Make slightly lower than 100e6 to account for rounding errors
+        actions.withdrawAndSwap(address(this), 99e6, 100e18);
+
+        assertEq(usdc.balanceOf(address(this)),                       99e6);
+        assertEq(sdai.convertToAssets(sdai.balanceOf(address(this))), 0.999999999999999998e18);  // Some dust left over
+    }
+
+    function test_redeemAndSwap() public {
+        uint256 shares = sdai.convertToShares(100e18);
+        deal(SDAI, address(this), shares);
+        sdai.approve(address(actions), shares);
+
+        assertEq(usdc.balanceOf(address(this)),                       0);
+        assertEq(sdai.convertToAssets(sdai.balanceOf(address(this))), 99.999999999999999999e18);  // Rounding
+
+        // Make slightly lower than 100e6 to account for rounding errors
+        actions.redeemAndSwap(address(this), shares, 99e6);
+
+        assertEq(usdc.balanceOf(address(this)),                       99.999999e6);
+        assertEq(sdai.convertToAssets(sdai.balanceOf(address(this))), 0);
+    }
+
+}


### PR DESCRIPTION
The psm lite has been deployed, and we need to migrate to the new version as liquidity will move over. I've bumped the solc version too as there was issues with verifying on Etherscan with `0.8.25`. An integration test sanity check was added too.